### PR TITLE
api 및 id 체크 로직 리팩토링

### DIFF
--- a/src/api/ApartDataApi.tsx
+++ b/src/api/ApartDataApi.tsx
@@ -5,9 +5,11 @@ import { KakaoSearchApi } from './KakaoSearchApi';
 const getPastDates = (years: number) => {
   const pastDates = [];
   const currentDate = new Date();
+  // pastDate를 years 변수로 받은 만큼 n년전 과거로 설정함.
   const pastDate = new Date();
   pastDate.setFullYear(pastDate.getFullYear() - years);
 
+  // pastDate가 currentDate보다 과거인 날짜~현재까지 반복.
   while (pastDate <= currentDate) {
     const year = pastDate.getFullYear();
     const month = pastDate.getMonth() + 1;
@@ -18,7 +20,7 @@ const getPastDates = (years: number) => {
   return pastDates;
 };
 
-// 페이지 최대갯수가 49인 관계로 1페이지를 초과하게되면 페이지를 넘어가서 조회를해야함
+// 페이지마다 데이터 행의 최대갯수가 49인 관계로 1페이지를 초과하게되면 페이지를 넘어가서 조회를해야함
 const fetchData = async (lawCityNumber: string, yyyymm: string, pageNo = 1): Promise<any[]> => {
   // const serviceKey =
   //   'J7KH6Ppo1yX4MSbd9yNXaeWvjo%2FcWuqKWSdnLBFFU1cnHfwPa1Ym4Ecc4ZtjUA0R0%2FNK%2FxdcZBZEbrKcwUQq0g%3D%3D';
@@ -31,7 +33,7 @@ const fetchData = async (lawCityNumber: string, yyyymm: string, pageNo = 1): Pro
   const proxyReqDTO = {
     pageNo,
     numOfRows: 49,
-    lawdCd: lawCityNumber,
+    lawdCd: lawCityNumber, // 법정동코드
     dealYmd: yyyymm,
   };
 
@@ -41,12 +43,15 @@ const fetchData = async (lawCityNumber: string, yyyymm: string, pageNo = 1): Pro
 
     const responseData = response.data.response.body.items.item;
     const { totalCount } = response.data.response.body;
+    // console.log(response);
 
+    // totalCount가 총 페이지 갯수인거 같음. 총 데이터 행이 49개를 넘으면 다음 페이지로,
     if (totalCount > pageNo * 49) {
+      // 다음 페이지를 추가로 fetch해서 nextPageItems으로.
       const nextPageItems = await fetchData(lawCityNumber, yyyymm, pageNo + 1);
+      // 그리고 nextPageItems를 responseData에 합치기.
       return responseData.concat(nextPageItems);
     }
-
     return responseData;
   } catch (error) {
     console.error('백앤드 요청 실패:', error);
@@ -54,44 +59,80 @@ const fetchData = async (lawCityNumber: string, yyyymm: string, pageNo = 1): Pro
   }
 };
 
-const ApartData = (adress: string) => {
-  // 카카오 법정동코드 추출
-  console.log(adress);
-  return KakaoSearchApi(adress).then((documents) => {
-    if (documents !== null) {
-      // 현재날자를 기준으로 몇년전 날자를 조회할것인지 월단위로 배열에 넣어줌
-      const pastDates = getPastDates(1);
+// const ApartData = (adress: string) => {
+//   // 카카오 법정동코드 추출
+//   // console.log(adress);
+//   return KakaoSearchApi(adress).then((documents) => {
+//     if (documents !== null) {
+//       // 현재날자를 기준으로 몇년전 날자를 조회할것인지 월단위로 배열에 넣어줌
+//       const pastDates = getPastDates(1);
 
-      const Bcode = documents.address.b_code;
-      const lawCityNumber = Bcode.slice(0, 5);
-      const lawSectionNumber = parseInt(Bcode.slice(5, 10), 10);
-      const roadNumber = documents.road_address.main_building_no.padStart(5, '0');
+//       const Bcode = documents.address.b_code;
+//       const lawCityNumber = Bcode.slice(0, 5);
+//       // Bcode의 5부터 10 전까지 문자열을 파싱해서 숫자로 바꿈. 이때, 10진수로 바꿈.
+//       // 원래는 10진수가 아닌가 보네?
+//       const lawSectionNumber = parseInt(Bcode.slice(5, 10), 10);
+//       const roadNumber = documents.road_address.main_building_no.padStart(5, '0');
 
-      const results: { [key: string]: any } = { filterDATA: {}, originalDATA: {} };
+//       const results: { [key: string]: any } = { filterDATA: {}, originalDATA: {} };
 
-      return Promise.all(
-        pastDates.map((yyyymm) => {
-          return fetchData(lawCityNumber, yyyymm)
-            .then((responseData) => {
-              const filteredData = responseData.filter(
-                (item: any) =>
-                  item.도로명건물본번호코드 === roadNumber &&
-                  item.법정동읍면동코드 === lawSectionNumber,
-              );
-              if (filteredData.length > 0) {
-                results.filterDATA[yyyymm] = filteredData;
-              }
-              return null; // 반환 값으로 null을 명시적으로 반환
-            })
-            .catch((error) => {
-              console.log(error);
+//       return Promise.all(
+//         pastDates.map((yyyymm) => {
+//           return fetchData(lawCityNumber, yyyymm)
+//             .then((responseData) => {
+//               const filteredData = responseData.filter(
+//                 (item: any) =>
+//                   item.도로명건물본번호코드 === roadNumber &&
+//                   item.법정동읍면동코드 === lawSectionNumber,
+//               );
+//               if (filteredData.length > 0) {
+//                 results.filterDATA[yyyymm] = filteredData;
+//               }
+//               return null; // 반환 값으로 null을 명시적으로 반환
+//             })
+//             .catch((error) => {
+//               console.log(error);
 
-              return null; // 반환 값으로 null을 명시적으로 반환
-            });
-        }),
-      ).then(() => results);
-    }
-  });
+//               return null; // 반환 값으로 null을 명시적으로 반환
+//             });
+//         }),
+//       ).then(() => results);
+//     }
+//   });
+// };
+
+const ApartData = async (address: string) => {
+  const documents = await KakaoSearchApi(address);
+
+  if (documents !== null) {
+    const pastDates = getPastDates(1);
+    const Bcode = documents.address.b_code;
+    const lawCityNumber = Bcode.slice(0, 5);
+    const lawSectionNumber = parseInt(Bcode.slice(5, 10), 10);
+    const roadNumber = documents.road_address.main_building_no.padStart(5, '0');
+    const results: { [key: string]: any } = { filterDATA: {}, originalDATA: {} };
+
+    await Promise.all(
+      pastDates.map(async (yyyymm) => {
+        try {
+          const responseData = await fetchData(lawCityNumber, yyyymm);
+          const filteredData = responseData.filter(
+            (item: any) =>
+              item.도로명건물본번호코드 === roadNumber &&
+              item.법정동읍면동코드 === lawSectionNumber,
+          );
+
+          if (filteredData.length > 0) {
+            results.filterDATA[yyyymm] = filteredData;
+          }
+        } catch (error) {
+          console.log(error);
+        }
+      }),
+    );
+
+    return results;
+  }
 };
 
 export default ApartData;

--- a/src/api/UploadApi.tsx
+++ b/src/api/UploadApi.tsx
@@ -5,16 +5,16 @@ import { MoreturnUrl } from '../utils/constants';
 // 반복횟수
 const maxRetries = 3;
 
-const createAxiosInstance = () => {
-  return axios.create({
-    baseURL: MoreturnUrl,
-    headers: {
-      'Content-Type': 'multipart/form-data',
-      accept: '*/*',
-    },
-    responseType: 'json',
-  });
-};
+// const createAxiosInstance = () => {
+//   return axios.create({
+//     baseURL: MoreturnUrl,
+//     headers: {
+//       'Content-Type': 'multipart/form-data',
+//       accept: '*/*',
+//     },
+//     responseType: 'json',
+//   });
+// };
 
 const handleRetry = async (error: any) => {
   const { config } = error;
@@ -29,12 +29,21 @@ const handleRetry = async (error: any) => {
   return Promise.reject(error);
 };
 
-const setupResponseInterceptor = (instance: AxiosInstance) => {
-  instance.interceptors.response.use(undefined, handleRetry);
-};
+// const setupResponseInterceptor = (instance: AxiosInstance) => {
+//   instance.interceptors.response.use(undefined, handleRetry);
+// };
 
-const instance = createAxiosInstance();
-setupResponseInterceptor(instance);
+// const instance = createAxiosInstance();
+const instance = axios.create({
+  baseURL: MoreturnUrl,
+  headers: {
+    'Content-Type': 'multipart/form-data',
+    accept: '*/*',
+  },
+  responseType: 'json',
+});
+// setupResponseInterceptor(instance);
+instance.interceptors.response.use(undefined, handleRetry);
 
 const cancelTokenSource = (): CancelTokenSource => {
   return axios.CancelToken.source();

--- a/src/components/Overview/PropertyInfo.tsx
+++ b/src/components/Overview/PropertyInfo.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
-import { Link, useParams } from 'react-router-dom';
-import { gray } from 'd3';
+import { useParams } from 'react-router-dom';
 import { useDataStore } from '../../store/DataStore';
-import { CommonButton } from '../common';
+import { getResData } from '@/utils/getResData';
 
 const PropertyInfo = () => {
   const { id } = useParams();
@@ -12,12 +11,6 @@ const PropertyInfo = () => {
 
   const [price, setPrice] = useState<any>(null);
   const [priceDate, setPriceDate] = useState<any>(null);
-
-  const [ownershipList, setOwnershipList] = useState<any[]>([]);
-
-  const [mortgage, setMortgage] = useState<any[]>([]);
-
-  const [maximumDebt, setMaximumDebt] = useState<any[]>([]);
 
   useEffect(() => {
     if (!id) {
@@ -33,27 +26,20 @@ const PropertyInfo = () => {
       console.log(`아이디 ${id}에 해당하는 아이템을 찾을 수 없습니다.`);
     }
   }, [id]);
+
+  const mortgage = Object.values(getResData('rights_other_than_ownership'));
+  const ownershipList = Object.values(getResData('ownership_list'));
+  const matximumDeb = Object.values(getResData('originalMoney'));
+  const dateKeys = Object.keys(getResData('customData.filterDATA')).map(Number);
+  const maxDateKey = Math.max(...dateKeys);
+  const maxDate = getResData('customData.filterDATA')[maxDateKey];
+
   useEffect(() => {
-    if (summary) {
-      const dateKeys = Object.keys(summary.data.customData.filterDATA).map(Number);
-      const ownershipListValues = Object.values(summary.data.ownership_list);
-      const ownership = Object.values(summary.data.rights_other_than_ownership);
-      const originalMoney = Object.values(summary.data.originalMoney);
-      setMaximumDebt(originalMoney);
-      setMortgage(ownership);
-      setOwnershipList(ownershipListValues);
-
-      if (dateKeys.length > 0) {
-        const maxDateKey = Math.max(...dateKeys);
-        const maxDate = summary.data.customData.filterDATA[maxDateKey];
-
-        if (maxDate.length > 0) {
-          setPriceDate(maxDateKey.toString());
-          setPrice(maxDate[maxDate.length - 1]);
-        }
-      }
+    if (maxDate.length > 0) {
+      setPriceDate(maxDateKey.toString());
+      setPrice(maxDate[maxDate.length - 1]);
     }
-  }, [summary]);
+  }, [maxDate]);
 
   return (
     <PraPropertyInfoWrap>
@@ -89,7 +75,7 @@ const PropertyInfo = () => {
           </ContentWrap>
         </FlexDiv>
         {ownershipList.length > 0 ? (
-          ownershipList.map((item, index) => (
+          ownershipList.map((item: any, index: any) => (
             // eslint-disable-next-line react/no-array-index-key
             <FlexDiv key={index}>
               <ContentWrap>

--- a/src/components/Table/MarketPrice/MarketPriceTable2.tsx
+++ b/src/components/Table/MarketPrice/MarketPriceTable2.tsx
@@ -1,28 +1,8 @@
-import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
 import Table from '@/components/common/Table';
-import { useDataStore } from '@/store/DataStore';
+import { getResData } from '@/utils/getResData';
 
 const MarketConditionsTable2 = () => {
-  const { id } = useParams();
-  const { responseItems } = useDataStore();
-  const [praPriceData, setPraPriceData] = useState<any>(null);
-
-  useEffect(() => {
-    if (!id) {
-      console.log('URL에 아이디가 제공되지 않았습니다.');
-      return;
-    }
-
-    const parsedId: number = +id;
-    const selectedItem: any = responseItems.find((item) => item.id === parsedId);
-
-    if (selectedItem) {
-      setPraPriceData(selectedItem.data.customData.filterDATA);
-    } else {
-      console.log(`아이디 ${id}에 해당하는 아이템을 찾을 수 없습니다.`);
-    }
-  }, [id]);
+  const praPriceData = getResData('customData.filterDATA');
 
   const result = praPriceData
     ? Object.entries(praPriceData)

--- a/src/components/Table/PdfSummary/PdfSummaryTable1.tsx
+++ b/src/components/Table/PdfSummary/PdfSummaryTable1.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
 import { Column } from 'react-table';
-import { useDataStore } from '@/store/DataStore';
 import Table, { TableProps } from '@/components/common/Table';
+import { getResData } from '@/utils/getResData';
 
 const COLUMNS: Column<{
   name: string;
@@ -34,26 +32,7 @@ const COLUMNS: Column<{
 ];
 
 const PdfSummaryTable1 = () => {
-  const { id } = useParams();
-  const { responseItems } = useDataStore();
-  const [resData, setResData] = useState();
-
-  console.log(responseItems);
-
-  useEffect(() => {
-    if (!id) {
-      console.log('URL에 아이디가 제공되지 않았습니다.');
-      return;
-    }
-    const parsedId: number = +id;
-    const selectedItem: any = responseItems.find((item) => item.id === parsedId);
-
-    if (selectedItem) {
-      setResData(selectedItem.data.ownership_list);
-    } else {
-      console.log(`아이디 ${id}에 해당하는 아이템을 찾을 수 없습니다.`);
-    }
-  }, [id]);
+  const resData = getResData('ownership_list');
 
   // 백엔드에서 obejct 타입으로 데이터를 response 함.  테이블에 넣기 위해 배열로 변경
   const ownerList = resData ? Object.values(resData) : [];

--- a/src/components/Table/PdfSummary/PdfSummaryTable3.tsx
+++ b/src/components/Table/PdfSummary/PdfSummaryTable3.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
 import { Column } from 'react-table';
-import { useDataStore } from '@/store/DataStore';
 import Table, { TableProps } from '@/components/common/Table';
+import { getResData } from '@/utils/getResData';
 
 const COLUMNS: Column<{
   rank: string;
@@ -34,24 +32,7 @@ const COLUMNS: Column<{
 ];
 
 const PdfSummaryTable3 = () => {
-  const { id } = useParams();
-  const { responseItems } = useDataStore();
-  const [resData, setResData] = useState();
-
-  useEffect(() => {
-    if (!id) {
-      console.log('URL에 아이디가 제공되지 않았습니다.');
-      return;
-    }
-    const parsedId: number = +id;
-    const selectedItem: any = responseItems.find((item) => item.id === parsedId);
-
-    if (selectedItem) {
-      setResData(selectedItem.data.rights_other_than_ownership);
-    } else {
-      console.log(`아이디 ${id}에 해당하는 아이템을 찾을 수 없습니다.`);
-    }
-  }, [id]);
+  const resData = getResData('rights_other_than_ownership');
 
   // 백엔드에서 obejct 타입으로 데이터를 response 함.  테이블에 넣기 위해 배열로 변경
   const rightsList = resData ? Object.values(resData) : [];

--- a/src/pages/Detailed/Location.tsx
+++ b/src/pages/Detailed/Location.tsx
@@ -1,34 +1,15 @@
 import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import { useDataStore } from '@/store/DataStore';
 import Map from '@/components/Map';
 import FacilityTable from '@/components/Table/Location/FacilityLists';
 import EstateAgentTable from '@/components/Table/Location/EstateAgentLists';
+import { getResData } from '@/utils/getResData';
 
 const Location = () => {
-  const { id } = useParams();
-  const { responseItems } = useDataStore();
-
-  const [address, setAddress] = useState<string>('');
   const [newLat, setLat] = useState<number>(0);
   const [newLng, setLng] = useState<number>(0);
+  const address = getResData('summary.newAddress');
   const link = `https://new.land.naver.com/complexes?ms=${newLat},${newLng},19`;
-
-  useEffect(() => {
-    if (!id) {
-      console.log('URL에 아이디가 제공되지 않았습니다.');
-      return;
-    }
-    const parsedId: number = +id;
-    const selectedItem: any = responseItems.find((item) => item.id === parsedId);
-
-    if (selectedItem) {
-      setAddress(selectedItem.data.summary.newAddress);
-    } else {
-      console.log(`아이디 ${id}에 해당하는 아이템을 찾을 수 없습니다.`);
-    }
-  }, [id]);
 
   // 주소 받으면 좌표로 변환해서 전역 상태로 저장
   useEffect(() => {

--- a/src/pages/Detailed/MarketPrice.tsx
+++ b/src/pages/Detailed/MarketPrice.tsx
@@ -1,35 +1,15 @@
 import styled from '@emotion/styled';
-import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
 import Chart from '@/components/Chart/';
-import { useDataStore } from '@/store/DataStore';
 import MarketPriceTable2 from '@/components/Table/MarketPrice/MarketPriceTable2';
+import { getResData } from '@/utils/getResData';
 
 const MarketPrice = () => {
-  const { id } = useParams();
-  const { responseItems } = useDataStore();
-  const [praPriceData, setPraPriceData] = useState<any>(null);
+  const praPriceData = getResData('customData.filterDATA');
 
   let minPrice = '';
   let maxPrice = '';
   let allMinPrice = '';
   let allMaxPrice = '';
-
-  useEffect(() => {
-    if (!id) {
-      console.log('URL에 아이디가 제공되지 않았습니다.');
-      return;
-    }
-
-    const parsedId: number = +id;
-    const selectedItem: any = responseItems.find((item) => item.id === parsedId);
-
-    if (selectedItem) {
-      setPraPriceData(selectedItem.data.customData.filterDATA);
-    } else {
-      console.log(`아이디 ${id}에 해당하는 아이템을 찾을 수 없습니다.`);
-    }
-  }, [id]);
 
   const result = praPriceData
     ? Object.entries(praPriceData)

--- a/src/pages/MyReviews/index.tsx
+++ b/src/pages/MyReviews/index.tsx
@@ -8,29 +8,25 @@ const MyReviews = () => {
   const [opened, setOpened] = useState<boolean>(false);
   const [message, setMessage] = useState<string>('');
 
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (mail.trim() === '') {
       setMessage('이메일을 제대로 기입하였는지 확인해 주세요.');
       setOpened(true);
       return;
     } else {
-      axios
-        .post('https://www.mollyteam.shop/presubscribe', {
+      try {
+        const response = await axios.post('https://www.mollyteam.shop/presubscribe', {
           email: mail,
-        })
-        .then((res) => {
-          console.log(res);
-          if (res.data.code === 200) {
-            setMessage('신청이 완료되었습니다.');
-            setOpened(true);
-          }
-        })
-        .catch((err) => {
-          console.log(err);
-          setMessage('오류가 발생했습니다. 다시 시도해 주세요.');
-          setOpened(true);
         });
+        if (response.data.code === 200) {
+          setMessage('신청이 완료되었습니다.');
+          setOpened(true);
+        }
+      } catch (error) {
+        setMessage('오류가 발생했습니다. 다시 시도해 주세요.');
+        setOpened(true);
+      }
     }
 
     setMail('');

--- a/src/utils/getResData.ts
+++ b/src/utils/getResData.ts
@@ -1,0 +1,22 @@
+import { useParams } from 'react-router-dom';
+import { useDataStore } from '@/store/DataStore';
+
+export const getResData = (data: string) => {
+  const { id } = useParams();
+  const { responseItems } = useDataStore();
+
+  if (!id) {
+    return null;
+  }
+
+  // id를 string에서 number로 전환
+  const parsedId: number = +id;
+
+  // 전역 상태의 responseItems에서 현재 id와 일치하는 item을 선택
+  const currentItem: any = responseItems.find((item) => item.id === parsedId);
+  if (currentItem) {
+    const datapath = data.split('.').reduce((obj, key) => obj?.[key], currentItem.data);
+    const responseData = datapath;
+    return responseData;
+  }
+};


### PR DESCRIPTION
## PR check list

- [x] 에러가 뜨는지 확인했는가
- [x] 커밋 컨벤션에 맞춰 남겼는가
- [x] 이슈를 남기고 작업한 내용인가

## PR type

- [x] 리팩토링 (코드 분리 및 통합도 포함)
- [ ] 디렉토리 및 환경설정 변경 (파일 삭제, 문서수정도 포함)
- [ ] css 작업
- [x] 코드 테스트
- [ ] 에러 수정

## Summary

ApartDataApi의 코드 개선
UploadApi의 필요없는 함수 삭제
id 체크하여 데이터 가져오는 컴포넌트들의 로직 중복 개선

## Describe your changes

ApartData는 .then 메서를 try-catch문으로 변경하여 가독성을 높이고, 코드 depth를 줄였다.

UploadApi에서 instance 선언을 위해 createAxiosInstance라는 함수와 interceptors 설정을 위해 setupResponseInterceptor함수를 실행하고 있다.
직업 instance와 interceptors를 선언하면 되므로 두 함수를 삭제하여 불필요한 과정을 줄였다.

PropertyInfo, 시세 테이블, pdf 요약부 테이블, Location, MarketPrice에서 현재 파라미터의 id를 체크하고 해당하는 데이터를 가져오는 로직을 사용하고 있다.
해당 로직이 각 컴포넌트에서 중복되어 사용되므로 이를 util 함수로 만들어 재사용성을 높이고 불필요한 코드 중복을 방지하였다.

## Issue number and link

#14 #15
