### PR TITLE
refactor: 에러 모달 중복 코드 컴포넌트화

### DIFF
--- a/src/components/PdfUploadModule/UploadModals/index.tsx
+++ b/src/components/PdfUploadModule/UploadModals/index.tsx
@@ -3,16 +3,24 @@ import { CommonButton, CommonModal } from '../../common';
 import { ModalContents, ModalTitle } from './style';
 import LoadingBar from '../LoadingBar';
 
-// 에러 모달 두개는 구조가 똑같으니까 함수로 추출해서 재사용함으로써 중복 코드 줄이기
-const renderErrorModal = (title: string, message: string, onClose: () => void) => {
+// 에러 모달 두개는 구조가 똑같으니까 컴포넌트로 추출해서 재사용함으로써 중복 코드 줄이기
+interface ErrorModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  message: string;
+}
+const ErrorModal = ({ isOpen, onClose, title, message }: ErrorModalProps) => {
   return (
-    <ModalContents>
-      <ModalTitle>{title}</ModalTitle>
-      <div style={{ color: 'red' }}>{message}</div>
-      <CommonButton width={200} height={50} type="button" onClick={onClose}>
-        확인
-      </CommonButton>
-    </ModalContents>
+    <CommonModal isOpen={isOpen} onClose={onClose} width={440} height={270}>
+      <ModalContents>
+        <ModalTitle>{title}</ModalTitle>
+        <div style={{ color: 'red' }}>{message}</div>
+        <CommonButton width={200} height={50} type="button" onClick={onClose}>
+          확인
+        </CommonButton>
+      </ModalContents>
+    </CommonModal>
   );
 };
 
@@ -50,26 +58,18 @@ const UploadModals = ({
   ViewChange,
 }: ModalProps) => (
   <>
-    <CommonModal
+    <ErrorModal
       isOpen={isErorrModalOpen}
       onClose={() => setErorrModalOpen(false)}
-      width={440}
-      height={270}
-    >
-      {renderErrorModal('파일 오류', modalMessage, () => setErorrModalOpen(false))}
-    </CommonModal>
-    <CommonModal
+      title="파일 오류"
+      message={modalMessage}
+    />
+    <ErrorModal
       isOpen={isUploadErorrModalOpen}
       onClose={() => setUploadErorrModalOpen(false)}
-      width={440}
-      height={270}
-    >
-      {renderErrorModal(
-        '업로드 오류',
-        '올바른 pdf파일이 아니거나 서버의 통신문제가 있습니다.',
-        () => setUploadErorrModalOpen(false),
-      )}
-    </CommonModal>
+      title="업로드 오류"
+      message="올바른 pdf파일이 아니거나 서버의 통신문제가 있습니다."
+    />
     <CommonModal
       isOpen={isModalOpen}
       onClose={() => {


### PR DESCRIPTION
이전에 내부 요소만 함수로 추출한 것보다 더 중복코드를 줄일 수 있도록
에러 모달 자체를 컴포넌트화 해서 재사용 가능토록 수정했다.

## PR check list

- [x] 에러가 뜨는지 확인했는가
- [x] 커밋 컨벤션에 맞춰 남겼는가
- [x] 이슈를 남기고 작업한 내용인가

## PR type

- [x] 리팩토링 (코드 분리 및 통합도 포함)
- [ ] 디렉토리 및 환경설정 변경 (파일 삭제, 문서수정도 포함)
- [ ] css 작업
- [ ] 코드 테스트
- [ ] 에러 수정

## Summary

업로드 모듈의 에러 모달 중복 코드 컴포넌트화

## Describe your changes

이전에 내부 요소만 함수로 추출한 것보다 더 중복코드를 줄일 수 있도록
에러 모달 자체를 컴포넌트화 해서 재사용 가능토록 수정했다.

## Issue number and link

#17